### PR TITLE
Remove implementation in String, and switch all keys in Map from Strings to Objects

### DIFF
--- a/map.h
+++ b/map.h
@@ -11,7 +11,8 @@
  * are .equals are equal, i.e. the map will never contain two keys which are
  * extensionally equivalent at the same time.
  */
-class Map : public Object {
+class Map : public Object
+{
 public:
   virtual ~Map(){};
 
@@ -19,22 +20,22 @@ public:
    * Returns the value which was set for this key.
    * Returns nullptr if not in map.
    */
-  virtual Object *get(String *key) = 0;
+  virtual Object *get(Object *key) = 0;
 
   /**
    * Set the value at the given key in this map.
    */
-  virtual void set(String *key, Object *value) = 0;
+  virtual void set(Object *key, Object *value) = 0;
 
   /**
    * Remove the value at the given key in this map. No-op if value not in map.
    */
-  virtual void remove(String *key) = 0;
+  virtual void remove(Object *key) = 0;
 
   /**
    * Determine if the given key is in this map.
    */
-  virtual bool has(String *key) = 0;
+  virtual bool has(Object *key) = 0;
 
   /**
    * Remove all keys from this map.
@@ -50,5 +51,5 @@ public:
    * Store keys in the given array. Caller responsible for allocating at least
    * Map::size() elements.
    */
-  virtual void keys(String **dest) = 0;
+  virtual void keys(Object **dest) = 0;
 };

--- a/object.h
+++ b/object.h
@@ -8,7 +8,8 @@
  * This represents a general object in the language.  It is the parent class of
  * all Objects.
  */
-class Object {
+class Object
+{
 public:
   virtual ~Object(){};
 

--- a/string.h
+++ b/string.h
@@ -7,33 +7,16 @@
 #include <stdlib.h>
 #include <string.h>
 
-class String : public Object {
+class String : public Object
+{
 public:
-  char *chars_;
-  size_t len_;
+  String() {}
 
-  String(const char *chars) {
-    size_t inputLen = strlen(chars) + 1;
-    chars_ = new char[inputLen];
-    memcpy(chars_, chars, inputLen);
+  ~String() {}
 
-    len_ = inputLen - 1;
-  }
+  size_t length() {}
 
-  ~String() { delete[] chars_; }
+  bool equals(Object *o) {}
 
-  size_t length() { return len_; }
-
-  bool equals(Object *o) {
-
-    String *otherString = dynamic_cast<String *>(o);
-
-    if (otherString == this) {
-      return true;
-    }
-
-    return strcmp(chars_, otherString->chars_) == 0;
-  }
-
-  size_t hash() { return 42; }
+  size_t hash() {}
 };


### PR DESCRIPTION
Hi,

I think the spec of Assignment1/part2 specifically prohibited having implementations for the String and Object class. I have removed any implementations in String.

Also, I believe the map must support both Object : Object as well as String : Object. I feel if we just make keys Objects, since a String is an Object, that will satisfy both requirements without much code repetition. 