### PR TITLE
New StringMap class, keys in Map class are Objects

### DIFF
--- a/map.h
+++ b/map.h
@@ -11,7 +11,8 @@
  * are .equals are equal, i.e. the map will never contain two keys which are
  * extensionally equivalent at the same time.
  */
-class Map : public Object {
+class Map : public Object
+{
 public:
   virtual ~Map(){};
 
@@ -19,22 +20,22 @@ public:
    * Returns the value which was set for this key.
    * Returns nullptr if not in map.
    */
-  virtual Object *get(String *key) = 0;
+  virtual Object *get(Object *key) = 0;
 
   /**
    * Set the value at the given key in this map.
    */
-  virtual void set(String *key, Object *value) = 0;
+  virtual void set(Object *key, Object *value) = 0;
 
   /**
    * Remove the value at the given key in this map. No-op if value not in map.
    */
-  virtual void remove(String *key) = 0;
+  virtual void remove(Object *key) = 0;
 
   /**
    * Determine if the given key is in this map.
    */
-  virtual bool has(String *key) = 0;
+  virtual bool has(Object *key) = 0;
 
   /**
    * Remove all keys from this map.
@@ -50,5 +51,5 @@ public:
    * Store keys in the given array. Caller responsible for allocating at least
    * Map::size() elements.
    */
-  virtual void keys(String **dest) = 0;
+  virtual void keys(Object **dest) = 0;
 };

--- a/map.h
+++ b/map.h
@@ -17,33 +17,50 @@ public:
   virtual ~Map(){};
 
   /**
-   * Returns the value which was set for this key.
-   * Returns nullptr if not in map.
+   * @brief Gets the Object at the given @param key
+   * 
+   * @param key the key to lookup the Object to retrieve
+   * @return Object* the retrieved Object
    */
-  virtual Object *get(Object *key) = 0;
+  virtual Object *get(String *key) = 0;
 
   /**
-   * Set the value at the given key in this map.
+   * @brief Sets the Object at the given @param key to the given @param value
+   * and returns the Object that was there originally
+   * 
+   * @param key the key to lookup the Object to replace
+   * @param value the value to set at the given @param key
+   * @return Object* the Object that was replaced
    */
-  virtual void set(Object *key, Object *value) = 0;
+  virtual Object *set(String *key, Object *value) = 0;
 
   /**
-   * Remove the value at the given key in this map. No-op if value not in map.
+   * @brief Removes the Object at the given @param key and returns it
+   * 
+   * @param key the key too lookup the Object to remove
+   * @return Object* the removed Object
    */
-  virtual void remove(Object *key) = 0;
+  virtual Object *remove(String *key) = 0;
 
   /**
-   * Determine if the given key is in this map.
+   * @brief Checks if the given key has a value in this Map
+   * 
+   * @param key the key to check for a corresponding value
+   * @return true if the given key maps to a value in this Map
+   * @return false if the given key does NOT map to a value in this Map
    */
-  virtual bool has(Object *key) = 0;
+  virtual bool has(String *key) = 0;
 
   /**
-   * Remove all keys from this map.
+   * @brief Removes all keys from this map
+   * 
    */
   virtual void clear() = 0;
 
   /**
-   * Return the number of entries in this map.
+   * @brief Gets the number of entries (i.e. key/value pairs) in this Map
+   * 
+   * @return size_t the number of entries
    */
   virtual size_t size() = 0;
 
@@ -51,5 +68,71 @@ public:
    * Store keys in the given array. Caller responsible for allocating at least
    * Map::size() elements.
    */
-  virtual void keys(Object **dest) = 0;
+  virtual void keys(String **dest) = 0;
+};
+
+/**
+ * A dictionary of string keys and object values.  All keys and values are owned
+ * by the caller, and none of the map's methods will modify them.  Keys which
+ * are .equals are equal, i.e. the map will never contain two keys which are
+ * extensionally equivalent at the same time.
+ */
+class StringMap : public Object
+{
+public:
+  virtual ~StringMap(){};
+
+  /**
+   * @brief Gets the String at the given @param key
+   * 
+   * @param key the key to lookup the String to retrieve
+   * @return String* the retrieved String
+   */
+  virtual String *get(String *key) = 0;
+
+  /**
+   * @brief Sets the String at the given @param key to the given @param value
+   * and returns the String that was there originally
+   * 
+   * @param key the key to lookup the String to replace
+   * @param value the value to set at the given @param key
+   * @return String* the String that was replaced
+   */
+  virtual String *set(String *key, String *value) = 0;
+
+  /**
+   * @brief Removes the String at the given @param key and returns it
+   * 
+   * @param key the key too lookup the String to remove
+   * @return String* the removed String
+   */
+  virtual String *remove(String *key) = 0;
+
+  /**
+   * @brief Checks if the given key has a value in this Map
+   * 
+   * @param key the key to check for a corresponding value
+   * @return true if the given key maps to a value in this Map
+   * @return false if the given key does NOT map to a value in this Map
+   */
+  virtual bool has(String *key) = 0;
+
+  /**
+   * @brief Removes all keys from this map
+   * 
+   */
+  virtual void clear() = 0;
+
+  /**
+   * @brief Gets the number of entries (i.e. key/value pairs) in this Map
+   * 
+   * @return size_t the number of entries
+   */
+  virtual size_t size() = 0;
+
+  /**
+   * Store keys in the given array. Caller responsible for allocating at least
+   * Map::size() elements.
+   */
+  virtual void keys(String **dest) = 0;
 };

--- a/map.h
+++ b/map.h
@@ -22,7 +22,7 @@ public:
    * @param key the key to lookup the Object to retrieve
    * @return Object* the retrieved Object
    */
-  virtual Object *get(String *key) = 0;
+  virtual Object *get(Object *key) = 0;
 
   /**
    * @brief Sets the Object at the given @param key to the given @param value
@@ -32,7 +32,7 @@ public:
    * @param value the value to set at the given @param key
    * @return Object* the Object that was replaced
    */
-  virtual Object *set(String *key, Object *value) = 0;
+  virtual Object *set(Object *key, Object *value) = 0;
 
   /**
    * @brief Removes the Object at the given @param key and returns it
@@ -40,7 +40,7 @@ public:
    * @param key the key too lookup the Object to remove
    * @return Object* the removed Object
    */
-  virtual Object *remove(String *key) = 0;
+  virtual Object *remove(Object *key) = 0;
 
   /**
    * @brief Checks if the given key has a value in this Map
@@ -49,7 +49,7 @@ public:
    * @return true if the given key maps to a value in this Map
    * @return false if the given key does NOT map to a value in this Map
    */
-  virtual bool has(String *key) = 0;
+  virtual bool has(Object *key) = 0;
 
   /**
    * @brief Removes all keys from this map
@@ -68,7 +68,7 @@ public:
    * Store keys in the given array. Caller responsible for allocating at least
    * Map::size() elements.
    */
-  virtual void keys(String **dest) = 0;
+  virtual void keys(Object **dest) = 0;
 };
 
 /**

--- a/object.h
+++ b/object.h
@@ -8,7 +8,8 @@
  * This represents a general object in the language.  It is the parent class of
  * all Objects.
  */
-class Object {
+class Object
+{
 public:
   virtual ~Object(){};
 

--- a/string.h
+++ b/string.h
@@ -7,33 +7,16 @@
 #include <stdlib.h>
 #include <string.h>
 
-class String : public Object {
+class String : public Object
+{
 public:
-  char *chars_;
-  size_t len_;
+  String() {}
 
-  String(const char *chars) {
-    size_t inputLen = strlen(chars) + 1;
-    chars_ = new char[inputLen];
-    memcpy(chars_, chars, inputLen);
+  ~String() {}
 
-    len_ = inputLen - 1;
-  }
+  size_t length() {}
 
-  ~String() { delete[] chars_; }
+  bool equals(Object *o) {}
 
-  size_t length() { return len_; }
-
-  bool equals(Object *o) {
-
-    String *otherString = dynamic_cast<String *>(o);
-
-    if (otherString == this) {
-      return true;
-    }
-
-    return strcmp(chars_, otherString->chars_) == 0;
-  }
-
-  size_t hash() { return 42; }
+  size_t hash() {}
 };


### PR DESCRIPTION
Same as the #6, but the Map class keys are `Object`s instead of `String`s